### PR TITLE
TUS1.0.0文件传输协议兼容性补丁

### DIFF
--- a/src/main/java/priv/dino/tus/server/manage/controller/UploadController.java
+++ b/src/main/java/priv/dino/tus/server/manage/controller/UploadController.java
@@ -185,8 +185,7 @@ public class UploadController {
             parameters = {@Parameter(in = ParameterIn.PATH, name = "id",
                     required = true, description = "上传工作单元的ID", schema = @Schema(type = "string", format = "SnowflakeID")),
                     @Parameter(name = "Upload-Offset", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "integer")),
-                    @Parameter(name = "Content-Length", in = ParameterIn.HEADER, required = true, schema = @Schema(type = "integer")),
-                    @Parameter(name = "Content-Type", example = "application/offset+octet-stream", required = true, schema = @Schema(type = "string"))})
+                    @Parameter(name = "Content-Type", in = ParameterIn.HEADER, required = true, example = "application/offset+octet-stream", schema = @Schema(type = "string"))})
     @RequestMapping(
             method = {RequestMethod.POST, RequestMethod.PATCH,},
             value = {"/{id}"},
@@ -195,8 +194,7 @@ public class UploadController {
     public Mono<ResponseEntity<Object>> uploadProcess(
             @NonNull @PathVariable("id") final Long id,
             @NonNull final ServerHttpRequest request,
-            @RequestHeader(name = "Upload-Offset") final long offset,
-            @RequestHeader(name = "Content-Length") final long length
+            @RequestHeader(name = "Upload-Offset") final long offset
     ) {
         request.getHeaders().forEach((k, v) -> log.debug("headers: {} {}", k, v));
 
@@ -204,7 +202,7 @@ public class UploadController {
         log.debug("SnowflakeID value: " + id);
 
         return uploadService
-                .uploadChunkAndGetUpdatedOffset(id, request.getBody(), offset, length)
+                .appendFileContent(id, request.getBody(), offset)
                 .log()
                 .map(e -> ResponseEntity
                         .status(NO_CONTENT)

--- a/src/main/java/priv/dino/tus/server/manage/handler/PatchHandler.java
+++ b/src/main/java/priv/dino/tus/server/manage/handler/PatchHandler.java
@@ -70,15 +70,11 @@ public class PatchHandler {
             rogueRequest = true;
         }
 
-        if (!contentLength.isPresent()) {
-            rogueRequest = true;
-        }
-
         if (rogueRequest) {
             return ServerResponse.badRequest().build();
         }
 
-        return uploadService.uploadChunkAndGetUpdatedOffset(Long.valueOf(uploadId),parts,offset.get(),contentLength.get())
+        return uploadService.appendFileContent(Long.valueOf(uploadId),parts,offset.orElseGet(() -> 0L))
                 .log()
                 .flatMap(r -> ServerResponse
                     .noContent()

--- a/src/main/java/priv/dino/tus/server/manage/router/DownloadRouter.java
+++ b/src/main/java/priv/dino/tus/server/manage/router/DownloadRouter.java
@@ -49,6 +49,6 @@ public class DownloadRouter {
     @Bean
     public RouterFunction<ServerResponse> route() {
         return RouterFunctions
-                        .route(GET("/download/{uploadId}").and(accept(MediaType.APPLICATION_JSON)), downloadHandler);
+                        .route(GET("/download/{uploadId}"), downloadHandler);
     }
 }

--- a/src/test/java/priv/dino/tus/server/manage/controller/UploadControllerTest.java
+++ b/src/test/java/priv/dino/tus/server/manage/controller/UploadControllerTest.java
@@ -1,10 +1,9 @@
-package priv.dino.tus.server.manage.controllers;
+package priv.dino.tus.server.manage.controller;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import priv.dino.tus.server.core.configuration.properties.TusServerProperties;
 import priv.dino.tus.server.core.util.UploadExpiredUtils;
-import priv.dino.tus.server.manage.controller.UploadController;
 import priv.dino.tus.server.manage.domain.File;
 import priv.dino.tus.server.manage.repository.FileRepository;
 import priv.dino.tus.server.manage.service.UploadService;
@@ -146,12 +145,12 @@ class UploadControllerTest {
                 put("test", Collections.singletonList("test"));
             }});
         Mockito
-            .when(uploadService.uploadChunkAndGetUpdatedOffset(1L, body, 0, 3))
+            .when(uploadService.appendFileContent(1L, body, 0))
             .thenReturn(Mono.just(File.builder().contentOffset(3L).build()));
 
 
         final UploadController uploadController = new UploadController(filesRepository, tusServerProperties, uploadService, uploadExpiredUtils);
-        uploadController.uploadProcess(1L, request, 0, 3)
+        uploadController.uploadProcess(1L, request, 0)
             .subscribe(v -> {
                 assertEquals(NO_CONTENT, v.getStatusCode());
                 assertEquals("3", Objects.requireNonNull(v.getHeaders().get("Upload-Offset")).get(0));


### PR DESCRIPTION
兼容性问题:

1. 调整上传协议中的`POST/PATCH` 请求应该允许客户端不填写 `Content-Length` 头, 上传字节数以实际 body 正文长度为准;
2. 改正下载文件限制`Content-Type`类型值导致无法下载的bug;
3. 下载附件中文文件名进行UTF-8 URLEncoder转义避免乱码;

测试环境对标的客户端为 https://github.com/tus/tus-java-client
```
<dependency>
  <groupId>io.tus.java.client</groupId>
  <artifactId>tus-java-client</artifactId>
  <version>0.5.0</version>
</dependency>
```

2024-7-17